### PR TITLE
Added error checking tests and some more error handling.

### DIFF
--- a/clang_build/clang_build.py
+++ b/clang_build/clang_build.py
@@ -357,7 +357,7 @@ def build(args, progress_disabled=True):
             if target.unsuccesful_builds:
                 outputs = [(file, output) for file, output in zip(
                         [t.name for t in target.unsuccesful_builds],
-                        [t.output_messages for t in target.unsuccesful_builds])]
+                        [t.depfile_message if t.depfile_failed else t.output_messages for t in target.unsuccesful_builds])]
                 errors[target.name] = outputs
 
                 logger.error(f'Target {target} did not compile. Errors:\n%s',

--- a/clang_build/clang_build.py
+++ b/clang_build/clang_build.py
@@ -135,9 +135,7 @@ def main():
     except _LinkError as link_error:
         logger.error('Compilation was unsuccessful:')
         for target, errors in link_error.error_dict.items():
-            printout = f'Target {target} did not link. Errors:'
-            for target, output in errors:
-                printout += f'\n{target}: {output}'
+            printout = f'Target {target} did not link. Errors:\n{errors}'
             logger.error(printout)
 
 
@@ -386,11 +384,7 @@ def build(args, progress_disabled=True):
         errors = {}
         for target in target_list:
             if target.unsuccessful_link:
-                outputs = [(target.name, target.link_report)]
-                # outputs = [(file, output) for file, output in zip(
-                #         [t.sourceFile for t in target.unsuccessful_link],
-                #         [t.depfile_message if t.depfile_failed else t.output_messages for t in target.unsuccessful_link])]
-                errors[target.name] = outputs
+                errors[target.name] = target.link_report
         if errors:
             raise _LinkError('Linking was unsuccessful', errors)
 

--- a/clang_build/errors.py
+++ b/clang_build/errors.py
@@ -16,3 +16,17 @@ class CompileError(RuntimeError):
         '''
         super().__init__(message)
         self.error_dict = error_dict
+
+class LinkError(RuntimeError):
+    '''
+    Error that is raised if linking was
+    not successful.
+    '''
+    def __init__(self, message, error_dict=None):
+        '''
+        :param message: Message of the error
+        :param error_dict: A dict containing all errors
+                           that occurred during compilation
+        '''
+        super().__init__(message)
+        self.error_dict = error_dict

--- a/clang_build/errors.py
+++ b/clang_build/errors.py
@@ -1,0 +1,18 @@
+'''
+Module containing custom errors that are
+raised by clang-build if something goes wrong.
+'''
+
+class CompileError(RuntimeError):
+    '''
+    Error that is raised if compilation was
+    not successful.
+    '''
+    def __init__(self, message, error_dict=None):
+        '''
+        :param message: Message of the error
+        :param error_dict: A dict containing all errors
+                           that occurred during compilation
+        '''
+        super().__init__(message)
+        self.error_dict = error_dict

--- a/clang_build/single_source.py
+++ b/clang_build/single_source.py
@@ -88,17 +88,18 @@ class SingleSource:
         # _LOGGER.debug('    ' + ' '.join(dependency_command))
         try:
             self.depfile_report = _subprocess.check_output(self.dependency_command, stderr=_subprocess.STDOUT).decode('utf-8').strip()
+            self.depfile_failed = False
         except _subprocess.CalledProcessError as error:
             self.depfile_failed = True
             self.depfile_report = error.output.decode('utf-8').strip()
 
-        # self.parse_depfile_output()
 
     def compile(self):
         # TODO: logging in multiprocess
         # _LOGGER.debug('    ' + ' '.join(self.compile_command))
         try:
             self.compile_report = _subprocess.check_output(self.compile_command, stderr=_subprocess.STDOUT).decode('utf-8').strip()
+            self.compilation_failed = False
         except _subprocess.CalledProcessError as error:
             self.compilation_failed = True
             self.compile_report = error.output.decode('utf-8').strip()
@@ -108,17 +109,6 @@ class SingleSource:
     def parse_compile_output(self):
         # Remove last line
         output_text = _re.split(r'(.*)\n.*generated\.$', self.compile_report)[0]
-
-        # Find all the indivdual messages
-        message_list = _re.split(_re.escape(str(self.sourceFile)), output_text)[1:]
-
-        # Get type, row, column and content of each message
-        message_parser = _re.compile(r':(?P<row>\d+):(?P<column>\d+):\s*(?P<type>error|warning):\s*(?P<message>[\s\S.]*)')
-        self.output_messages = [message_parser.search(message).groupdict() for message in message_list]
-
-    def parse_depfile_output(self):
-        # Remove last line
-        output_text = _re.split(r'(.*)\n.*generated\.$', self.depfile_report)[0]
 
         # Find all the indivdual messages
         message_list = _re.split(_re.escape(str(self.sourceFile)), output_text)[1:]

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -140,14 +140,13 @@ class HeaderOnly(Target):
     def compile(self, process_pool, progress_disabled):
         _LOGGER.info(f'Header-only target [{self.name}] does not require compiling.')
 
-def generateDepfile(buildable):
-    buildable.generate_dependency_file()
-
 def generate_depfile_single_source(buildable):
     buildable.generate_depfile()
+    return buildable
 
 def compile_single_source(buildable):
     buildable.compile()
+    return buildable
 
 class Compilable(Target):
 
@@ -283,7 +282,7 @@ class Compilable(Target):
         _LOGGER.info(f'Scan dependencies of target [{self.outname}]')
         for b in self.neededBuildables:
             _LOGGER.debug(' '.join(b.dependency_command))
-        list(_get_build_progress_bar(
+        self.neededBuildables = list(_get_build_progress_bar(
                 process_pool.imap(
                     generate_depfile_single_source,
                     self.neededBuildables),
@@ -295,7 +294,7 @@ class Compilable(Target):
         _LOGGER.info(f'Compile target [{self.outname}]')
         for b in self.neededBuildables:
             _LOGGER.debug(' '.join(b.compile_command))
-        list(_get_build_progress_bar(
+        self.neededBuildables = list(_get_build_progress_bar(
                 process_pool.imap(
                     compile_single_source,
                     self.neededBuildables),

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -120,7 +120,7 @@ class Target:
         self.includeDirectories = list(set(self.includeDirectories))
         self.headers = list(set(self.headers))
 
-        self.unsuccesful_builds = []
+        self.unsuccessful_builds = []
 
     def get_include_directory_command(self):
         return [f'-I{dir}' for dir in self.includeDirectories]
@@ -222,7 +222,7 @@ class Compilable(Target):
             clangpp=self.clangpp) for sourceFile in self.sourceFiles]
 
         # If compilation of buildables fail, they will be stored here later
-        self.unsuccesful_builds = []
+        self.unsuccessful_builds = []
 
         # Linking setup
         self.linkCommand = link_command + [str(self.outfile)]
@@ -302,7 +302,7 @@ class Compilable(Target):
                 total=len(self.neededBuildables),
                 name=self.name))
 
-        self.unsuccesful_builds = [buildable for buildable in self.neededBuildables if (buildable.compilation_failed or buildable.depfile_failed)]
+        self.unsuccessful_builds = [buildable for buildable in self.neededBuildables if (buildable.compilation_failed or buildable.depfile_failed)]
 
 
     def link(self):
@@ -318,18 +318,16 @@ class Compilable(Target):
             _os.chdir(originalDir)
             _LOGGER.info(f'Finished pre-link step of target [{self.name}]')
 
-        # Execute link command
         _LOGGER.info(f'Link target [{self.name}]')
-        # TODO: Capture output
         _LOGGER.debug('    ' + ' '.join(self.linkCommand))
 
-        self.linker_error = None
+        # Execute link command
         try:
-            _subprocess.check_output(self.linkCommand)
-        except _subprocess.CalledProcessError as e:
-            error_message = f'Error linking target [{self.name}] with message: {e}'
-            _LOGGER.error(error_message)
-            raise RuntimeError(error_message)
+            self.link_report = _subprocess.check_output(self.linkCommand, stderr=_subprocess.STDOUT).decode('utf-8').strip()
+            self.unsuccessful_link = False
+        except _subprocess.CalledProcessError as error:
+            self.unsuccessful_link = True
+            self.link_report = error.output.decode('utf-8').strip()
 
         ## After-build step
         if self.afterBuildScript:

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -302,7 +302,7 @@ class Compilable(Target):
                 total=len(self.neededBuildables),
                 name=self.name))
 
-        self.unsuccesful_builds = [buildable for buildable in self.neededBuildables if buildable.compilation_failed]
+        self.unsuccesful_builds = [buildable for buildable in self.neededBuildables if (buildable.compilation_failed or buildable.depfile_failed)]
 
 
     def link(self):

--- a/test/mwe_build_error/hello.cpp
+++ b/test/mwe_build_error/hello.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+    int i = 10
+}

--- a/test/test.py
+++ b/test/test.py
@@ -9,7 +9,7 @@ from pathlib import Path as _Path
 from multiprocessing import freeze_support
 
 from clang_build import clang_build
-
+from clang_build.errors import CompileError
 
 def on_rm_error( func, path, exc_info):
     # path contains the path of the file that couldn't be removed
@@ -28,6 +28,10 @@ class TestClangBuild(unittest.TestCase):
             self.fail('Could not run compiled program')
 
         self.assertEqual(output, 'Hello!')
+
+    def test_compile_error(self):
+        with self.assertRaises(CompileError):
+            clang_build.build(clang_build.parse_args(['-d', 'test/mwe_build_error']), False)
 
     def test_script_call(self):
         try:
@@ -67,7 +71,7 @@ class TestClangBuild(unittest.TestCase):
             output = subprocess.check_output(['./build/default/bin/main'], stderr=subprocess.STDOUT).decode('utf-8').strip()
         except subprocess.CalledProcessError:
             self.fail('Could not run compiled program')
-        
+
         self.assertEqual(output, 'Calculated Magic: 30')
 
     def test_toml_mwe(self):


### PR DESCRIPTION
- Fix: Linking and compiling did not store the error information as they were only generated in the child processes and never passed back to the parent process.
- Add: A new CompileError class is now raised that contains all errors that occurred during compilation
- Add: That checks that a buggy C++ file raises a CompileError
- Main method of clang-build now catches compile errors and prints them to screen before terminating the application