### PR TITLE
Added "version" property for external targets.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,10 +173,11 @@ Note:
 
     [mylib]
     url = "https://github.com/trick-17/mylib"
-    version = 1.1 # will try to git checkout [v]1.1[.*]
+    version = 1.1 # will try to `git checkout 1.1`
     directory = "sources"           # will point to "build/mylib/external_sources/sources"
-    include_directories = ["mylib/include"] # will point to "build/mylib/external_sources/sources/mylib"
-    source_directories  = ["mylib/src"] # will point to "build/mylib/external_sources/sources/mylib"
+    [mylib.sources]
+    include_directories = ["mylib/include"] # will point to "build/mylib/external_sources/sources/mylib/include"
+    source_directories  = ["mylib/src"]     # will point to "build/mylib/external_sources/sources/mylib/src"
     # Maybe we need to deactivate annoying warnings coming from the library
     [mylib.flags]
     compile = ["-Wno-deprecated-declarations", "-Wno-self-assign"]

--- a/test/boost-filesystem/clang-build.toml
+++ b/test/boost-filesystem/clang-build.toml
@@ -1,0 +1,91 @@
+[myexe]
+target_type = "executable"
+dependencies = ["filesystem"]
+
+[system]
+target_type = "static library"
+url = "https://github.com/boostorg/system"
+version = "boost-1.65.0"
+dependencies = ["core", "winapi", "config", "predef", "assert"]
+[system.flags]
+compile = ['-DBOOST_NO_CXX11_HDR_SYSTEM_ERROR', '-Wno-deprecated-declarations']
+
+[filesystem]
+target_type = "static library"
+url = "https://github.com/boostorg/filesystem"
+version = "boost-1.65.0"
+dependencies = ["throw_exception", "functional", "smart_ptr", "config", "io", "range", "detail", "system", "core", "type_traits", "predef", "assert", "iterator", "mpl", "static_assert"]
+[filesystem.flags]
+compile = ["-Wno-parentheses-equality"]
+
+[winapi]
+url = "https://github.com/boostorg/winapi"
+version = "boost-1.65.0"
+
+[config]
+url = "https://github.com/boostorg/config"
+version = "boost-1.65.0"
+
+[core]
+url = "https://github.com/boostorg/core"
+version = "boost-1.65.0"
+
+[smart_ptr]
+url = "https://github.com/boostorg/smart_ptr"
+version = "boost-1.65.0"
+
+[preprocessor]
+url = "https://github.com/boostorg/preprocessor"
+version = "boost-1.65.0"
+
+[mpl]
+url = "https://github.com/boostorg/mpl"
+version = "boost-1.65.0"
+dependencies = ["preprocessor"]
+
+[io]
+url = "https://github.com/boostorg/io"
+version = "boost-1.65.0"
+
+[detail]
+url = "https://github.com/boostorg/detail"
+version = "boost-1.65.0"
+
+[functional]
+url = "https://github.com/boostorg/functional"
+version = "boost-1.65.0"
+
+[throw_exception]
+url = "https://github.com/boostorg/throw_exception"
+version = "boost-1.65.0"
+
+[iterator]
+url = "https://github.com/boostorg/iterator"
+version = "boost-1.65.0"
+dependencies = ["detail"]
+
+[predef]
+url = "https://github.com/boostorg/predef"
+version = "boost-1.65.0"
+
+[range]
+url = "https://github.com/boostorg/range"
+version = "boost-1.65.0"
+
+[assert]
+url = "https://github.com/boostorg/assert"
+version = "boost-1.65.0"
+
+[static_assert] # has sources which should not be included
+target_type = "header only"
+url = "https://github.com/boostorg/static_assert"
+version = "boost-1.65.0"
+
+[utility] # has sources which should not be included
+target_type = "header only"
+url = "https://github.com/boostorg/utility"
+version = "boost-1.65.0"
+
+[type_traits]
+url = "https://github.com/boostorg/type_traits"
+version = "boost-1.65.0"

--- a/test/boost-filesystem/main.cpp
+++ b/test/boost-filesystem/main.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <boost/filesystem.hpp>
+using namespace std;
+using namespace boost::filesystem;
+
+int main(int argc, char* argv[])
+{
+    if (argc < 2)
+    {
+        cout << "Usage: tut2 path\n";
+        return 1;
+    }
+
+    path p(argv[1]);  // avoid repeated path construction below
+
+    if (exists(p))    // does path p actually exist?
+    {
+        if (is_regular_file(p))        // is path p a regular file?
+            cout << p << " size is " << file_size(p) << '\n';
+
+        else if (is_directory(p))      // is path p a directory?
+            cout << p << " is a directory\n";
+
+        else
+            cout << p << " exists, but is not a regular file or directory\n";
+    }
+    else
+        cout << p << " does not exist\n";
+
+    return 0;
+}

--- a/test/test.py
+++ b/test/test.py
@@ -137,6 +137,16 @@ class TestClangBuild(unittest.TestCase):
 
         self.assertEqual(output, 'Hello! mylib::triple(3) returned 9')
 
+    def test_boost_filesystem(self):
+        clang_build_try_except(['-d', 'test/boost-filesystem', '-V', '-p'])
+
+        try:
+            output = subprocess.check_output(['./build/myexe/default/bin/myexe', 'build'], stderr=subprocess.STDOUT).decode('utf-8').strip()
+        except subprocess.CalledProcessError:
+            self.fail('Could not run compiled program')
+
+        self.assertEqual(output, '"build" is a directory')
+
     # def test_openmp(self):
     #     clang_build_try_except(['-d', 'test/openmp', '-V', '-p'])
 


### PR DESCRIPTION
When version is specified, clang-build will try to checkout that tag.
Also fixed a minor bug in the error message for circular dependencies.
Minor fixes to some paths in Readme.