### PR TITLE
Tests and Examples: automatic discovery and build (WIP)

### DIFF
--- a/clang_build/clang_build.py
+++ b/clang_build/clang_build.py
@@ -96,6 +96,23 @@ def parse_args(args):
     parser.add_argument('--no-graph',
                         help='deactivates output of a dependency graph dotfile',
                         action='store_true')
+
+    parser.add_argument('--test',
+                        help='automatically discover and build tests on top of regular targets of the root project',
+                        action='store_true')
+
+    parser.add_argument('--test-recursive',
+                        help='automatically discover and build tests on top of regular targets of all projects. Implies --test',
+                        action='store_true')
+
+    parser.add_argument('--examples',
+                        help='automatically discover and build examples on top of regular targets of the root project',
+                        action='store_true')
+
+    parser.add_argument('--examples-recursive',
+                        help='automatically discover and build examples on top of regular targets of all projects. Implies --examples',
+                        action='store_true')
+
     return parser.parse_args(args=args)
 
 
@@ -179,6 +196,16 @@ class _Environment:
         self.force_build = True if args.force_build else False
         if self.force_build:
             self.logger.info('Forcing build...')
+
+        # Whether to discover and build tests of root project
+        self.test = True if (args.test or args.test_recursive) else False
+        # Whether to discover and build tests of all projects
+        self.test_recursive = True if args.test_recursive else False
+
+        # Whether to discover and build examples of root project
+        self.examples = True if (args.examples or args.examples_recursive) else False
+        # Whether to discover and build examples of all projects
+        self.examples_recursive = True if args.examples_recursive else False
 
         # Multiprocessing pool
         self.processpool = _Pool(processes = args.jobs)

--- a/clang_build/io_tools.py
+++ b/clang_build/io_tools.py
@@ -6,12 +6,12 @@ from . import platform as _platform
 def _get_header_files_in_folders(folders, exclude_patterns=[], recursive=True):
     delimiter = '/**/' if recursive else '/*'
     patterns  = [str(folder) + delimiter + ext for ext in ('*.hpp', '*.hxx', '*.h') for folder in folders]
-    return _get_files_in_patterns(patterns)
+    return _get_files_in_patterns(patterns, exclude_patterns=exclude_patterns, recursive=recursive)
 
 def _get_source_files_in_folders(folders, exclude_patterns=[], recursive=True):
     delimiter = '/**/' if recursive else '/*'
     patterns  = [str(folder) + delimiter + ext for ext in ('*.cpp', '*.cxx', '*.c') for folder in folders]
-    return _get_files_in_patterns(patterns)
+    return _get_files_in_patterns(patterns, exclude_patterns=exclude_patterns, recursive=recursive)
 
 def _get_files_in_patterns(patterns, exclude_patterns=[], recursive=True):
     included = [_Path(f) for pattern in patterns         for f in _iglob(str(pattern), recursive=recursive) if _Path(f).is_file()]

--- a/clang_build/project.py
+++ b/clang_build/project.py
@@ -409,7 +409,8 @@ class Project:
         for subproject in self.subprojects:
             targetlist += subproject.get_targets(exclude)
         targetlist += [target for target in self.target_list if target.identifier not in exclude]
-        targetlist += [target.test_target for target in targetlist if target.test_target]
+        for target in targetlist:
+            targetlist += target.test_targets
         return targetlist
 
     def contains_target(self, identifier):

--- a/clang_build/project.py
+++ b/clang_build/project.py
@@ -409,6 +409,7 @@ class Project:
         for subproject in self.subprojects:
             targetlist += subproject.get_targets(exclude)
         targetlist += [target for target in self.target_list if target.identifier not in exclude]
+        targetlist += [target.test_target for target in targetlist if target.test_target]
         return targetlist
 
     def contains_target(self, identifier):


### PR DESCRIPTION
**Not yet ready for merging**

- Closes  #72

The goal of this PR is to bring this feature far enough that at least a few boost libraries can be built including tests and examples and that there be some reasonable way of executing the tests.
GLFW will be another case to try this on.

- [x] implement folder discovery
- [x] ability to build tests
- [ ] ability to build examples
- [ ] (de-)activation of building test/example executables via CLI flags, correctly decide if there are any tests to be built
- [ ] better dependency graph dotfiles (the tests and examples would clutter the main graph, they should be shown separately)
- [ ] unit tests