### PR TITLE
Removed list mangling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - language: cpp
       os: osx
       env: DEPLOY=false
-      osx_image: xcode8
+      osx_image: xcode10
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi

--- a/clang_build/io_tools.py
+++ b/clang_build/io_tools.py
@@ -45,8 +45,8 @@ def get_sources_and_headers(target_options, target_root_directory, target_build_
     if 'linux' in target_options and _platform.PLATFORM == 'linux':
         exclude_options += target_options['linux'].get('headers_exclude', [])
 
-    include_patterns = list(set([target_root_directory.joinpath(path) for path in include_options]))
-    exclude_patterns = list(set([target_root_directory.joinpath(path) for path in exclude_options]))
+    include_patterns = list(set(target_root_directory.joinpath(path) for path in include_options))
+    exclude_patterns = list(set(target_root_directory.joinpath(path) for path in exclude_options))
 
     # Find header files
     if include_patterns:
@@ -77,8 +77,8 @@ def get_sources_and_headers(target_options, target_root_directory, target_build_
     if 'linux' in target_options and _platform.PLATFORM == 'linux':
         exclude_options += target_options['linux'].get('headers_exclude', [])
 
-    include_patterns = list(set([target_root_directory.joinpath(path) for path in include_options_public]))
-    exclude_patterns = list(set([target_root_directory.joinpath(path) for path in exclude_options]))
+    include_patterns = list(set(target_root_directory.joinpath(path) for path in include_options_public))
+    exclude_patterns = list(set(target_root_directory.joinpath(path) for path in exclude_options))
 
     # Find header files
     if include_patterns:
@@ -109,8 +109,8 @@ def get_sources_and_headers(target_options, target_root_directory, target_build_
     if 'linux' in target_options and _platform.PLATFORM == 'linux':
         exclude_options += target_options['linux'].get('sources_exclude', [])
 
-    sources_patterns = list(set([target_root_directory.joinpath(path) for path in sources_options]))
-    exclude_patterns = list(set([target_root_directory.joinpath(path) for path in exclude_options]))
+    sources_patterns = list(set(target_root_directory.joinpath(path) for path in sources_options))
+    exclude_patterns = list(set(target_root_directory.joinpath(path) for path in exclude_options))
 
     # Find source files from patterns
     if sources_patterns:

--- a/clang_build/project.py
+++ b/clang_build/project.py
@@ -171,13 +171,13 @@ class Project:
                 _LOGGER.info(f'Only building targets [{"], [".join(environment.target_list)}] out of base set of targets [{"], [".join(base_set)}].')
                 for target in self.targets_config:
                     if target not in environment.target_list:
-                        base_set -= {target}
+                        base_set.remove(target)
 
             # Descendants will be retained, too
             self.target_dont_build_list = set(dependency_graph.nodes())
             for root_name in base_set:
                 root_identifier = f'{self.identifier}.{root_name}' if self.identifier else root_name
-                self.target_dont_build_list -= {root_identifier}
+                self.target_dont_build_list.remove(root_identifier)
                 self.target_dont_build_list -= _nx.algorithms.dag.descendants(dependency_graph, root_identifier)
             self.target_dont_build_list = list(self.target_dont_build_list)
 
@@ -186,7 +186,7 @@ class Project:
 
         elif is_root_project:
             _LOGGER.info(f'Building all targets!')
-            base_set = set({})
+            base_set = set()
 
         # Create a dotfile of the dependency graph
         if is_root_project and environment.create_dependency_dotfile:

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -81,8 +81,8 @@ class Target:
             # Public include directories are forwarded
             self.include_directories_public += target.include_directories_public
 
-        self.include_directories = list(set([dir.resolve() for dir in self.include_directories]))
-        self.headers = list(set(self.headers))
+        self.include_directories = list(dict.fromkeys(dir.resolve() for dir in self.include_directories))
+        self.headers = list(dict.fromkeys(self.headers))
 
         # C language family dialect
         if 'properties' in options and 'cpp_version' in options['properties']:
@@ -145,7 +145,7 @@ class Target:
                 self.compile_flags += target.compile_flags_public
                 self.link_flags    += target.link_flags_public
 
-        self.compile_flags = list(set(self.compile_flags))
+        self.compile_flags = list(dict.fromkeys(self.compile_flags))
 
         # Interface flags
         cf, lf = self.parse_flags_options(options, 'interface-flags')

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ from multiprocessing import freeze_support as _freeze_support
 if __name__ == '__main__':
     _freeze_support()
     setuptools.setup(
-        python_requires='>=3.6',
+        python_requires='>=3.7',
         setup_requires=['pbr<4'],
         pbr=True)


### PR DESCRIPTION
Regarding #74, this merge request removes most occurences of `set` where we might want to preserve the order. Compile flags for sure need the order preserved. For the include paths I think it shouldn't be advertised, but for debugging purposes it is better if the include paths are in a somewhat reasonable order.