### PR TITLE
Fix Travis CI OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - language: python
       os: linux
       env: DEPLOY=true
-      python: 3.7
+      python: 3.6
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - language: python
       os: linux
       env: DEPLOY=true
-      python: 3.6
+      python: 3.7
       addons:
         apt:
           packages:
@@ -31,12 +31,12 @@ matrix:
       env: DEPLOY=false
       osx_image: xcode10
 
-before_install:
+before_install: # these might be chached, so we add `|| true`
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew upgrade python; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew upgrade python || true; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then curl https://bootstrap.pypa.io/get-pip.py | python3; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/bin:$PATH; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install llvm; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install llvm || true; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/opt/llvm/bin:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export LIBRARY_PATH=/usr/local/opt/llvm/lib:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ln -s /usr/lib/libiomp5.so /usr/lib/libomp.so; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,16 @@ matrix:
       os: osx
       env: DEPLOY=false
       osx_image: xcode10
+      addons:
+        homebrew:
+          packages:
+          - llvm
+          update: true
 
-before_install: # these might be chached, so we add `|| true`
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew upgrade python || true; fi
+before_install:
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew upgrade python || true; fi # this might be chached, so we add `|| true`
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then curl https://bootstrap.pypa.io/get-pip.py | python3; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/bin:$PATH; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install llvm || true; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/opt/llvm/bin:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export LIBRARY_PATH=/usr/local/opt/llvm/lib:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ln -s /usr/lib/libiomp5.so /usr/lib/libomp.so; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-cache:
-  directories:
-  - /usr/local/Cellar
-
 env:
   global:
     - secure: "WDG1lYvH4eJUqtzX/+lA+CRRHuRdjLUvJQDb4OIQ8LhrTS2VNrFtjFOO2L4BPOothwoB7WMBd4Sgd5x4DHilvqYlj8O9Jfe2rBXZbZC73I9weCBezgJ1l2eM7fFkUrnhqW8QOXRI4ALE4bhSwW6y/CMOhkLW++xw0AVlWnF+gLa44V/dPBoaQODkS5Rn/k+vE4cwyyMBLFoTXvCKeyQQZBTZ5t3VV3QLR+gpcti+GfnkAkozBEjUpWGuafu4Z+rsqvvadErP/lihM0QjDxbKv5BXFTpts1ooSj0L4i9ga0qbNuD9sSGpj2TPV8qAomZqaoIsi9PCep4StcyuFhvPKt860WrIvCNi3yBG4N7DfH4rHruOHfDT7bUZtLWJ7qlVwdrs/qz7t0l6VpnInw1WoBFbC7Jbd0qFD/38AzkZ4UKHgh+Zp5gUPdOs5oLgHq59YEzkS/2Lv7dMU98BT5TpcqqJhvzBclW0xqUz3yabgw3rOpVfmiwoVSgtCJfkgJy7xJDd78Mr1JmWOT4/zkZBNTHDnfZtRGNfyEXOeohL6JrtRft1o/qKypsA2pi86H0bAM4j0KBBCpptgpckNvS2vdRUZlBWJRISp/sEEQdoT+u9YIDPpa8Kr1tzbdXLoIV4K+FIW3dvWSkVwL+IFpvQzcpKMWTHKXawzBai42Fccfo="
@@ -37,9 +33,7 @@ matrix:
           update: true
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew upgrade python || true; fi # this might be chached, so we add `|| true`
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then curl https://bootstrap.pypa.io/get-pip.py | python3; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/bin:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/opt/llvm/bin:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export LIBRARY_PATH=/usr/local/opt/llvm/lib:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ln -s /usr/lib/libiomp5.so /usr/lib/libomp.so; fi


### PR DESCRIPTION
Caching the homebrew-installed components should save a lot of time, but it seems to produce problems, as e.g. `brew upgrade python` can fail when the cache is loaded (because Python 3.7 is already installed).