### PR TITLE
Fix flags and parsing of flags

### DIFF
--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -22,7 +22,7 @@ class Target:
     DEFAULT_COMPILE_FLAGS                = ['-Wall', '-Wextra', '-Wpedantic', '-Wshadow', '-Werror']
     DEFAULT_COMPILE_FLAGS_RELEASE        = ['-O3', '-DNDEBUG']
     DEFAULT_COMPILE_FLAGS_RELWITHDEBINFO = ['-O3', '-g3', '-DNDEBUG']
-    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-O0', '-g3', '-DDEBUG',
+    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-Og', '-g3', '-DDEBUG',
                                             '-fno-optimize-sibling-calls', '-fno-omit-frame-pointer']
     DEFAULT_COMPILE_FLAGS_COVERAGE       = DEFAULT_COMPILE_FLAGS_DEBUG + [
                                             '--coverage',

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -22,8 +22,9 @@ class Target:
     DEFAULT_COMPILE_FLAGS                = ['-Wall', '-Wextra', '-Wpedantic', '-Wshadow', '-Werror']
     DEFAULT_COMPILE_FLAGS_RELEASE        = ['-O3', '-DNDEBUG']
     DEFAULT_COMPILE_FLAGS_RELWITHDEBINFO = ['-O3', '-g3', '-DNDEBUG']
-    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-Og', '-g3', '-DDEBUG',
-                                            '-fno-optimize-sibling-calls', '-fno-omit-frame-pointer']
+    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-Og', '-g3', '-DDEBUG']
+    DEFAULT_EXE_LINK_FLAGS_DEBUG         = []
+    DEFAULT_EXE_LINK_FLAGS_COVERAGE      = DEFAULT_EXE_LINK_FLAGS_DEBUG + ['--coverage']
     DEFAULT_COMPILE_FLAGS_COVERAGE       = DEFAULT_COMPILE_FLAGS_DEBUG + [
                                             '--coverage',
                                             '-fno-inline']
@@ -456,6 +457,11 @@ class Executable(Compilable):
         for target in self.dependency_targets:
             if not target.__class__ is HeaderOnly:
                 self.link_command += ['-L', str(target.output_folder.resolve())]
+
+        if self.build_type == _BuildType.Debug:
+            self.link_flags += Target.DEFAULT_EXE_LINK_FLAGS_DEBUG
+        elif self.build_type == _BuildType.Coverage:
+            self.link_flags += Target.DEFAULT_EXE_LINK_FLAGS_COVERAGE
 
         self.link_command += self.link_flags
 

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -19,10 +19,11 @@ from .progress_bar import get_build_progress_bar as _get_build_progress_bar
 _LOGGER = _logging.getLogger('clang_build.clang_build')
 
 class Target:
-    DEFAULT_COMPILE_FLAGS                = ['-Wall', '-Wextra', '-Wpedantic', '-Werror']
+    DEFAULT_COMPILE_FLAGS                = ['-Wall', '-Wextra', '-Wpedantic', '-Wshadow', '-Werror']
     DEFAULT_COMPILE_FLAGS_RELEASE        = ['-O3', '-DNDEBUG']
     DEFAULT_COMPILE_FLAGS_RELWITHDEBINFO = ['-O3', '-g3', '-DNDEBUG']
-    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-O0', '-g3', '-DDEBUG']
+    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-O0', '-g3', '-DDEBUG',
+                                            '-fno-optimize-sibling-calls', '-fno-omit-frame-pointer']
     DEFAULT_COMPILE_FLAGS_COVERAGE       = DEFAULT_COMPILE_FLAGS_DEBUG + [
                                             '--coverage',
                                             '-fno-inline']

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -22,8 +22,10 @@ class Target:
     DEFAULT_COMPILE_FLAGS                = ['-Wall', '-Wextra', '-Wpedantic', '-Wshadow', '-Werror']
     DEFAULT_COMPILE_FLAGS_RELEASE        = ['-O3', '-DNDEBUG']
     DEFAULT_COMPILE_FLAGS_RELWITHDEBINFO = ['-O3', '-g3', '-DNDEBUG']
-    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-Og', '-g3', '-DDEBUG']
-    DEFAULT_EXE_LINK_FLAGS_DEBUG         = []
+    DEFAULT_COMPILE_FLAGS_DEBUG          = ['-Og', '-g3', '-DDEBUG',
+                                            '-fno-optimize-sibling-calls', '-fno-omit-frame-pointer',
+                                            '-fsanitize=address', '-fsanitize=undefined']
+    DEFAULT_EXE_LINK_FLAGS_DEBUG         = ['-fsanitize=address', '-fsanitize=undefined']
     DEFAULT_EXE_LINK_FLAGS_COVERAGE      = DEFAULT_EXE_LINK_FLAGS_DEBUG + ['--coverage']
     DEFAULT_COMPILE_FLAGS_COVERAGE       = DEFAULT_COMPILE_FLAGS_DEBUG + [
                                             '--coverage',

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -154,6 +154,10 @@ class Target:
         self.compile_flags = list(dict.fromkeys(self.compile_flags))
         self.link_flags    = list(dict.fromkeys(self.link_flags))
 
+        # Split strings containing spaces
+        self.compile_flags = list(str(' '.join(self.compile_flags)).split())
+        self.link_flags    = list(str(' '.join(self.link_flags)).split())
+
     # Parse compile and link flags of any kind ('flags', 'interface-flags', ...)
     def parse_flags_options(self, options, flags_kind='flags'):
         flags_dicts   = []
@@ -171,8 +175,8 @@ class Target:
             flags_dicts.append(options['linux'].get(flags_kind, {}))
 
         for fdict in flags_dicts:
-            compile_flags     += fdict.get('compile', [])
-            link_flags        += fdict.get('link', [])
+            compile_flags += fdict.get('compile', [])
+            link_flags    += fdict.get('link', [])
 
             if self.build_type == _BuildType.Release:
                 compile_flags += fdict.get('compile_release', [])

--- a/test/test.py
+++ b/test/test.py
@@ -48,7 +48,7 @@ class TestClangBuild(unittest.TestCase):
         self.assertEqual(output, 'Hello!')
 
     def test_build_types(self):
-        for build_type in ['release', 'relwithdebinfo', 'debug']:
+        for build_type in ['release', 'relwithdebinfo', 'debug', 'coverage']:
             clang_build_try_except(['-d', 'test/mwe', '-b', build_type])
 
             try:

--- a/test/test.py
+++ b/test/test.py
@@ -47,6 +47,17 @@ class TestClangBuild(unittest.TestCase):
 
         self.assertEqual(output, 'Hello!')
 
+    def test_build_types(self):
+        for build_type in ['release', 'relwithdebinfo', 'debug']:
+            clang_build_try_except(['-d', 'test/mwe', '-b', build_type])
+
+            try:
+                output = subprocess.check_output([f'./build/{build_type}/bin/main'], stderr=subprocess.STDOUT).decode('utf-8').strip()
+            except subprocess.CalledProcessError as e:
+                self.fail(f'Could not run compiled program with build type "{build_type}". Message:\n{e.output}')
+
+            self.assertEqual(output, 'Hello!')
+
     def test_compile_error(self):
         with self.assertRaises(CompileError):
             clang_build.build(clang_build.parse_args(['-d', 'test/mwe_build_error', '-V']))


### PR DESCRIPTION
Closes #39 and #97.

- fixed parsing flags containing whitespace (e.g. `-framework Cocoa`)
- added `-Wshadow` to default flags
- changed optimization flag in debug build type from `-O0` to `-Og`
- added address and undefined behaviour sanitizers to debug build
- added missing link flag in coverage build type
- added unit test for build types, including coverage build type