### PR TITLE
Made contradicting cla's mutually exclusive.

### DIFF
--- a/clang_build/clang_build.py
+++ b/clang_build/clang_build.py
@@ -72,10 +72,11 @@ def parse_args(args):
                         type=_BuildType,
                         default=_BuildType.Default,
                         help='set the build type for this project')
-    parser.add_argument('-a', '--all',
+    target_group = parser.add_mutually_exclusive_group()
+    target_group.add_argument('-a', '--all',
                         help='build every target, irrespective of whether any root target depends on it',
                         action='store_true')
-    parser.add_argument('-t', '--targets',
+    target_group.add_argument('-t', '--targets',
                         type=str,
                         default="",
                         help='only these targets and their dependencies should be built (comma-separated list)')


### PR DESCRIPTION
For the command-line arguments of clang-build one can specify to build "ALL" targets, meaning those targets not needed by the top-level project are still selected to be build. Or one can select those targets one wishes to build (and all their dependencies). It doesn't make sense to provide both. With this patch, the user will be informed that they provided contradicting arguments.