### PR TITLE
Config change: `public_flags` and `interface_flags` instead of `public-flags` and `interface-flags`.

### DIFF
--- a/clang_build/flags.py
+++ b/clang_build/flags.py
@@ -63,12 +63,12 @@ class BuildFlags:
         self.link_private += lf
 
         # Own interface flags
-        cf, lf = self._parse_flags_config(config, platform, "interface-flags")
+        cf, lf = self._parse_flags_config(config, platform, "interface_flags")
         self.compile_interface += cf
         self.link_interface += lf
 
         # Own public flags
-        cf, lf = self._parse_flags_config(config, platform, "public-flags")
+        cf, lf = self._parse_flags_config(config, platform, "public_flags")
         self.compile_public += cf
         self.link_public += lf
 

--- a/docs/user_guide/inheritance.rst
+++ b/docs/user_guide/inheritance.rst
@@ -5,13 +5,13 @@ Inheritance
 Include directories
 ----------------------------------------------
 
-**`include-directories`**
+**`include_directories`**
 
     A list of private include directories, i.e. accessible only to the target itself.
 
     Defaults are the target directory and "include".
 
-**`public-include-directories`**
+**`include_directories_public`**
 
     A list of public include directories, which are accessible to any dependent target.
     Note that these are forwarded up the dependency graph, i.e. a target adds all of
@@ -25,7 +25,7 @@ Include directories
 
     [mylib]
         include_directories = ["src/mylib/include", "src/mylib/detail/include"]
-        public_include_directories = ["src/mylib/include"]
+        include_directories_public = ["src/mylib/include"]
 
 
 Flags
@@ -39,7 +39,7 @@ The following sections of a target configuration can each contain `compile` and
     Private flags which are only applied to the target itself, with the exception
     of header-only libraries, for which they are added to the public flags.
 
-**`interface-flags`**
+**`interface_flags`**
 
     Interface flags are potentially applied to dependent targets, but not the target itself.
     An example use-case is a static library, which depends on a dynamic library, which can
@@ -49,13 +49,13 @@ The following sections of a target configuration can each contain `compile` and
     to themselves (i.e. add them to their own `flags`) and will not forward them.
 
     Header only and static libraries will not apply their dependencies' interface flags to
-    themselves, but will forward them (i.e. add them to their own `interface-flags`).
+    themselves, but will forward them (i.e. add them to their own `interface_flags`).
 
-**`public-flags`**
+**`public_flags`**
 
     Public flags are applied to the target and any dependent target.
 
-    Public flags are always forwarded (i.e. added to a target's own `public-flags`).
+    Public flags are always forwarded (i.e. added to a target's own `public_flags`).
 
 
 Note a slightly subtle difference between interface and public flags:

--- a/docs/user_guide/platform_dependence.rst
+++ b/docs/user_guide/platform_dependence.rst
@@ -7,7 +7,7 @@ Per-Platform Target Configuration
 
 The following lists and sections of the target configuration can be specified individually per platform:
 
-- `include_directories` and `public_include_directories`
+- `include_directories` and `include_directories_public`
 - `sources`
 - `flags`
 
@@ -26,7 +26,7 @@ Example
         include_directories_public = ["include"]
         sources = ["src/common.c"]
 
-        [mylib.public-flags]
+        [mylib.public_flags]
             compile = ["-DMYLIB_VERSION_MAJOR=2", "-DMYLIB_VERSION_MINOR=1", "-DMYLIB_VERSION_PATCH=2"]
 
         [mylib.osx]
@@ -35,7 +35,7 @@ Example
 
             [mylib.osx.flags]
                 compile = ["-DMYLIB_OSX"]
-            [mylib.osx.interface-flags]
+            [mylib.osx.interface_flags]
                 link = ["-framework", "Cocoa"]
 
         [mylib.windows]

--- a/test/boost-filesystem/boost_dependencies/clang-build.toml
+++ b/test/boost-filesystem/boost_dependencies/clang-build.toml
@@ -13,7 +13,7 @@ target_type = "static library"
 url = "https://github.com/boostorg/system"
 version = "boost-1.65.0"
 dependencies = ["core", "winapi", "config", "predef", "assert"]
-[system.flags]
+[system.public_flags]
 compile = ['-DBOOST_NO_CXX11_HDR_SYSTEM_ERROR', '-Wno-deprecated-declarations', '-Wno-language-extension-token']
 
 [winapi]

--- a/test/c-library/qhull/clang-build.toml
+++ b/test/c-library/qhull/clang-build.toml
@@ -30,7 +30,7 @@ version = "v7.2.0"
     sources = ["src/libqhull/*.c"]
     [qhullstatic.flags]
         compile = ["-Wno-deprecated-declarations"]
-    [qhullstatic.linux.interface-flags]
+    [qhullstatic.linux.interface_flags]
         link = ["-lm"]
 
 [qhullstatic_r]
@@ -39,7 +39,7 @@ version = "v7.2.0"
     sources = ["src/libqhull_r/*.c"]
     [qhullstatic_r.flags]
         compile = ["-Wno-deprecated-declarations"]
-    [qhullstatic_r.linux.interface-flags]
+    [qhullstatic_r.linux.interface_flags]
         link = ["-lm"]
 
 # Executables


### PR DESCRIPTION
Also corrected documentation on include directories.

This is half of issue #113.