### PR TITLE
Made include directory config names consistent.

### DIFF
--- a/clang_build/directories.py
+++ b/clang_build/directories.py
@@ -4,7 +4,7 @@ class Directories:
 
         # Include directories
         self.include_private = files["include_directories"]
-        self.include_public = files["include_directories_public"]
+        self.include_public = files["public_include_directories"]
 
         # Default include path
         # if self.root_directory.joinpath('include').exists():

--- a/clang_build/io_tools.py
+++ b/clang_build/io_tools.py
@@ -17,7 +17,7 @@ def _get_files_in_patterns(patterns, exclude_patterns=[], recursive=True):
     return list(f.resolve() for f in (set(included) - set(excluded)))
 
 def get_sources_and_headers(target_name, platform, target_options, target_root_directory, target_build_directory):
-    output = {'headers': [], 'include_directories': [], 'include_directories_public': [], 'sourcefiles': []}
+    output = {'headers': [], 'include_directories': [], 'public_include_directories': [], 'sourcefiles': []}
 
     # TODO: maybe the output should also include the root dir, build dir and potentially download dir?
     # TODO: should warn when a specified directory does not exist!
@@ -47,25 +47,25 @@ def get_sources_and_headers(target_name, platform, target_options, target_root_d
 
     # Options for public include directories, exclude patterns are the same
     include_options_public = []
-    include_options_public += target_options.get('include_directories_public', [])
+    include_options_public += target_options.get('public_include_directories', [])
 
-    include_options_public += target_options.get(platform, {}).get('include_directories_public', [])
+    include_options_public += target_options.get(platform, {}).get('public_include_directories', [])
 
     include_patterns = list(dict.fromkeys(target_root_directory.joinpath(path) for path in include_options_public))
     exclude_patterns = list(dict.fromkeys(target_root_directory.joinpath(path) for path in exclude_options))
 
     # Find header files
     if include_patterns:
-        output['include_directories_public'] = include_patterns
-        output['headers'] += _get_header_files_in_folders(output['include_directories_public'], exclude_patterns=exclude_patterns, recursive=True)
+        output['public_include_directories'] = include_patterns
+        output['headers'] += _get_header_files_in_folders(output['public_include_directories'], exclude_patterns=exclude_patterns, recursive=True)
     else:
-        output['include_directories_public'] += [target_root_directory.joinpath(''), target_root_directory.joinpath('include'),
+        output['public_include_directories'] += [target_root_directory.joinpath(''), target_root_directory.joinpath('include'),
                                                 target_root_directory.joinpath(target_name, 'include')]
-        output['headers'] += _get_header_files_in_folders(output['include_directories_public'], exclude_patterns=exclude_patterns, recursive=False)
+        output['headers'] += _get_header_files_in_folders(output['public_include_directories'], exclude_patterns=exclude_patterns, recursive=False)
 
     # Keep only include directories which exist
     output['include_directories'] = [directory for directory in output['include_directories'] if directory.exists()]
-    output['include_directories_public'] = [directory for directory in output['include_directories_public'] if directory.exists()]
+    output['public_include_directories'] = [directory for directory in output['public_include_directories'] if directory.exists()]
 
     # Options for sources
     sources_options = []
@@ -94,7 +94,7 @@ def get_sources_and_headers(target_name, platform, target_options, target_root_d
 
     # Fill return dict
     output['include_directories']        = list(dict.fromkeys(output['include_directories'] ))
-    output['include_directories_public'] = list(dict.fromkeys(output['include_directories_public'] ))
+    output['public_include_directories'] = list(dict.fromkeys(output['public_include_directories'] ))
     output['headers']                    = list(dict.fromkeys(output['headers'] ))
     output['sourcefiles']                = list(dict.fromkeys(output['sourcefiles'] ))
 

--- a/docs/user_guide/inheritance.rst
+++ b/docs/user_guide/inheritance.rst
@@ -11,7 +11,7 @@ Include directories
 
     Defaults are the target directory and "include".
 
-**`include_directories_public`**
+**`public_include_directories`**
 
     A list of public include directories, which are accessible to any dependent target.
     Note that these are forwarded up the dependency graph, i.e. a target adds all of
@@ -25,7 +25,7 @@ Include directories
 
     [mylib]
         include_directories = ["src/mylib/include", "src/mylib/detail/include"]
-        include_directories_public = ["src/mylib/include"]
+        public_include_directories = ["src/mylib/include"]
 
 
 Flags

--- a/docs/user_guide/platform_dependence.rst
+++ b/docs/user_guide/platform_dependence.rst
@@ -7,7 +7,7 @@ Per-Platform Target Configuration
 
 The following lists and sections of the target configuration can be specified individually per platform:
 
-- `include_directories` and `include_directories_public`
+- `include_directories` and `public_include_directories`
 - `sources`
 - `flags`
 
@@ -23,7 +23,7 @@ Example
 
     [mylib]
         target_type = "static library"
-        include_directories_public = ["include"]
+        public_include_directories = ["include"]
         sources = ["src/common.c"]
 
         [mylib.public_flags]

--- a/test/c-library/qhull/clang-build.toml
+++ b/test/c-library/qhull/clang-build.toml
@@ -18,7 +18,7 @@ version = "v7.2.0"
 
 [qhullcpp]
     target_type = "static library"
-    include_directories_public = ["src"]
+    public_include_directories = ["src"]
     sources = ["src/libqhullcpp/*.cpp"]
     sources_exclude = ["src/libqhullcpp/qt-qhull.cpp", "src/libqhullcpp/usermem_r-cpp.cpp"]
     [qhullcpp.flags]
@@ -26,7 +26,7 @@ version = "v7.2.0"
 
 [qhullstatic]
     target_type = "static library"
-    include_directories_public = ["src"]
+    public_include_directories = ["src"]
     sources = ["src/libqhull/*.c"]
     [qhullstatic.flags]
         compile = ["-Wno-deprecated-declarations"]
@@ -35,7 +35,7 @@ version = "v7.2.0"
 
 [qhullstatic_r]
     target_type = "static library"
-    include_directories_public = ["src"]
+    public_include_directories = ["src"]
     sources = ["src/libqhull_r/*.c"]
     [qhullstatic_r.flags]
         compile = ["-Wno-deprecated-declarations"]


### PR DESCRIPTION
`include_directories_public` is now called `public_include_directories`, analogous to `public_flags` etc.

Closes #113.