### PR TITLE
Compilation database / compile_commands.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
 
   deploy-pypi:
-    if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
+    if: github.event_name == 'push' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
     needs: test
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Clang-build
 **Goals:**
 
 - One compiler (Clang), one build system (written in Python)
+- Automatic integration with language servers (compile_commands.json)
 - Simple projects should be simple to build
 - Build process for reasonable project structures should still be easy
 - Adding third-party dependencies should be manageable

--- a/clang_build/environment.py
+++ b/clang_build/environment.py
@@ -7,6 +7,8 @@ import shutil as _shutil
 from multiprocessing import Pool as _Pool
 from pathlib import Path as _Path
 
+import json
+
 from . import __version__
 from .build_type import BuildType as _BuildType
 from .toolchain import LLVM as _Clang
@@ -19,7 +21,6 @@ class Environment:
     """
 
     def __init__(self, args):
-
 
         self.toolchain = _Clang()
 
@@ -51,3 +52,8 @@ class Environment:
         if self.redistributable:
             self.bundle = True
             _LOGGER.info("Redistributable bundling of binary dependencies is activated")
+
+        self.compilation_database_file = (self.build_directory / 'compile_commands.json')
+        self.compilation_database = []
+        if self.compilation_database_file.exists():
+            self.compilation_database = json.loads(self.compilation_database_file.read_text())

--- a/clang_build/single_source.py
+++ b/clang_build/single_source.py
@@ -5,6 +5,8 @@ import subprocess as _subprocess
 from multiprocessing import freeze_support as _freeze_support
 # import logging as _logging
 
+import json
+
 
 # Find and parse the dependency file, return list of headers this file depends on
 # See e.g. https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Preprocessor-Options.html#Preprocessor-Options for documentation
@@ -54,6 +56,8 @@ class SingleSource:
             compile_flags,
             is_c_target):
 
+        self._environment = environment
+
         # Get the relative file path
         self.name        = source_file.name
         self.source_file = source_file
@@ -80,7 +84,7 @@ class SingleSource:
 
 
     def generate_depfile(self):
-        success, self.depfile_report = self.toolchain.generate_dependency_file(
+        command, success, self.depfile_report = self.toolchain.generate_dependency_file(
             self.source_file,
             self.depfile,
             self.flags,
@@ -88,14 +92,72 @@ class SingleSource:
             self.is_c_target)
         self.depfile_failed = not success
 
+        # TODO: make this a part of `Environment`
+        database_file = (self._environment.build_directory / 'compile_commands.json')
+        database = []
+        if database_file.exists():
+            database = json.loads(database_file.read_text())
+
+        command_missing = True
+        for idx, db_command in enumerate(database):
+            if str(self.source_file) == db_command["file"] and str(self.depfile) == db_command["output"]:
+                database[idx] = {
+                    'directory': str(self._environment.build_directory),
+                    'command': ' '.join(command),
+                    'file': str(self.source_file),
+                    'output': str(self.depfile)
+                }
+                command_missing = False
+                break
+        if command_missing:
+            database.append({
+                'directory': str(self._environment.build_directory),
+                'command': ' '.join(command),
+                'file': str(self.source_file),
+                'output': str(self.depfile)
+            })
+
+        database_file.write_text(
+            json.dumps(database, indent=4, sort_keys=True)
+        )
+
     def compile(self):
-        success, self.compile_report = self.toolchain.compile(
+        command, success, self.compile_report = self.toolchain.compile(
             self.source_file,
             self.object_file,
             self.include_directories,
             self.flags,
             self.is_c_target)
         self.compilation_failed = not success
+
+        # TODO: make this a part of `Environment`
+        database_file = (self._environment.build_directory / 'compile_commands.json')
+        database = []
+        if database_file.exists():
+            database = json.loads(database_file.read_text())
+
+        command_missing = True
+        for idx, db_command in enumerate(database):
+            if str(self.source_file) == db_command["file"] and str(self.object_file) == db_command["output"]:
+                database[idx] = {
+                    'directory': str(self._environment.build_directory),
+                    'command': ' '.join(command),
+                    'file': str(self.source_file),
+                    'output': str(self.object_file)
+                }
+                command_missing = False
+                break
+        if command_missing:
+            database.append({
+                'directory': str(self._environment.build_directory),
+                'command': ' '.join(command),
+                'file': str(self.source_file),
+                'output': str(self.object_file)
+            })
+
+        database_file.write_text(
+            json.dumps(database, indent=4, sort_keys=True)
+        )
 
 if __name__ == '__name__':
     _freeze_support()

--- a/clang_build/single_source.py
+++ b/clang_build/single_source.py
@@ -5,8 +5,6 @@ import subprocess as _subprocess
 from multiprocessing import freeze_support as _freeze_support
 # import logging as _logging
 
-import json
-
 
 # Find and parse the dependency file, return list of headers this file depends on
 # See e.g. https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Preprocessor-Options.html#Preprocessor-Options for documentation
@@ -111,10 +109,6 @@ class SingleSource:
                 'output': str(self.depfile)
             })
 
-        self._environment.compilation_database_file.write_text(
-            json.dumps(self._environment.compilation_database, indent=4, sort_keys=True)
-        )
-
     def compile(self):
         command, success, self.compile_report = self.toolchain.compile(
             self.source_file,
@@ -143,9 +137,6 @@ class SingleSource:
                 'output': str(self.object_file)
             })
 
-        self._environment.compilation_database_file.write_text(
-            json.dumps(self._environment.compilation_database, indent=4, sort_keys=True)
-        )
 
 if __name__ == '__name__':
     _freeze_support()

--- a/clang_build/single_source.py
+++ b/clang_build/single_source.py
@@ -92,16 +92,10 @@ class SingleSource:
             self.is_c_target)
         self.depfile_failed = not success
 
-        # TODO: make this a part of `Environment`
-        database_file = (self._environment.build_directory / 'compile_commands.json')
-        database = []
-        if database_file.exists():
-            database = json.loads(database_file.read_text())
-
         command_missing = True
-        for idx, db_command in enumerate(database):
+        for idx, db_command in enumerate(self._environment.compilation_database):
             if str(self.source_file) == db_command["file"] and str(self.depfile) == db_command["output"]:
-                database[idx] = {
+                self._environment.compilation_database[idx] = {
                     'directory': str(self._environment.build_directory),
                     'command': ' '.join(command),
                     'file': str(self.source_file),
@@ -110,15 +104,15 @@ class SingleSource:
                 command_missing = False
                 break
         if command_missing:
-            database.append({
+            self._environment.compilation_database.append({
                 'directory': str(self._environment.build_directory),
                 'command': ' '.join(command),
                 'file': str(self.source_file),
                 'output': str(self.depfile)
             })
 
-        database_file.write_text(
-            json.dumps(database, indent=4, sort_keys=True)
+        self._environment.compilation_database_file.write_text(
+            json.dumps(self._environment.compilation_database, indent=4, sort_keys=True)
         )
 
     def compile(self):
@@ -130,16 +124,10 @@ class SingleSource:
             self.is_c_target)
         self.compilation_failed = not success
 
-        # TODO: make this a part of `Environment`
-        database_file = (self._environment.build_directory / 'compile_commands.json')
-        database = []
-        if database_file.exists():
-            database = json.loads(database_file.read_text())
-
         command_missing = True
-        for idx, db_command in enumerate(database):
+        for idx, db_command in enumerate(self._environment.compilation_database):
             if str(self.source_file) == db_command["file"] and str(self.object_file) == db_command["output"]:
-                database[idx] = {
+                self._environment.compilation_database[idx] = {
                     'directory': str(self._environment.build_directory),
                     'command': ' '.join(command),
                     'file': str(self.source_file),
@@ -148,15 +136,15 @@ class SingleSource:
                 command_missing = False
                 break
         if command_missing:
-            database.append({
+            self._environment.compilation_database.append({
                 'directory': str(self._environment.build_directory),
                 'command': ' '.join(command),
                 'file': str(self.source_file),
                 'output': str(self.object_file)
             })
 
-        database_file.write_text(
-            json.dumps(database, indent=4, sort_keys=True)
+        self._environment.compilation_database_file.write_text(
+            json.dumps(self._environment.compilation_database, indent=4, sort_keys=True)
         )
 
 if __name__ == '__name__':

--- a/clang_build/target.py
+++ b/clang_build/target.py
@@ -10,6 +10,8 @@ from abc import abstractmethod
 from multiprocessing import freeze_support as _freeze_support
 from pathlib import Path as _Path
 
+import json
+
 from .directories import Directories
 from .errors import BundleError as _BundleError
 from .errors import CompileError as _CompileError
@@ -376,6 +378,10 @@ class Compilable(Target):
                 name=self.name,
             )
         )
+        # Update database with depfile commands
+        self._environment.compilation_database_file.write_text(
+            json.dumps(self._environment.compilation_database, indent=2, sort_keys=True)
+        )
 
         # Execute compile command
         self._logger.info("compile object files")
@@ -386,6 +392,10 @@ class Compilable(Target):
                 total=len(self.needed_buildables),
                 name=self.name,
             )
+        )
+        # Update database with compile commands
+        self._environment.compilation_database_file.write_text(
+            json.dumps(self._environment.compilation_database, indent=2, sort_keys=True)
         )
 
         # Catch compilation errors

--- a/clang_build/toolchain.py
+++ b/clang_build/toolchain.py
@@ -323,12 +323,8 @@ class LLVM:
 
         """
         object_file.parents[0].mkdir(parents=True, exist_ok=True)
-
-        return self._run_clang_command(
-            self._get_compiler_command(
-                source_file, object_file, include_directories, flags, is_c_target
-            )
-        )
+        command = self._get_compiler_command(source_file, object_file, include_directories, flags, is_c_target)
+        return command, *self._run_clang_command(command)
 
     def generate_dependency_file(
         self, source_file, dependency_file, flags, include_directories, is_c_target
@@ -359,12 +355,8 @@ class LLVM:
         """
         dependency_file.parents[0].mkdir(parents=True, exist_ok=True)
 
-        return self._run_clang_command(
-            self._get_compiler_command(
-                source_file, None, include_directories, flags, is_c_target
-            )
-            + ["-E", "-MMD", str(source_file), "-MF", str(dependency_file)]
-        )
+        command = self._get_compiler_command(source_file, None, include_directories, flags, is_c_target) + ["-E", "-MMD", str(source_file), "-MF", str(dependency_file)]
+        return command, *self._run_clang_command(command)
 
     def link(
         self,


### PR DESCRIPTION
TODO:
- [x] output compile_commands.json, with separate commands for the separate compile-stages (depfile and objfile)
- [x] reasonable performance, don't constantly re-parse the json
- [x] test (including printing to console)
- [x] mention the feature in the docs

Maybe
- [ ] update database _before_ actually calling the commands
- [ ] find a different pattern than requiring a set of three return values from the `Toolchain.generate_dependency_file` and `Toolchain.compile` functions
- [ ] find a way to "prune" or "clean" the database of entries that are no longer needed or relevant but which will currently hurt performance

Closes #109.