### PR TITLE
First try of making standard C++ modules buildable

### DIFF
--- a/clang_build/directories.py
+++ b/clang_build/directories.py
@@ -12,6 +12,10 @@ class Directories:
         self.include_private = files["include_directories"]
         self.include_public = files["public_include_directories"]
 
+        # Module directories
+        self.module_private = []
+        self.module_public = []
+
         # Default include path
         # if self.root_directory.joinpath('include').exists():
         #    self._include_directories_public = [self.root_directory.joinpath('include')] + self._include_directories_public
@@ -19,12 +23,18 @@ class Directories:
         # Public include directories of private dependencies are applied
         for target in dependencies:
             self.include_private += target.directories.include_public
+            self.module_private = target.directories.module_public
+            # if target.__class__ is not HeaderOnly:
+            self.module_private += [target.output_folder]
 
         # Public include directories of public dependencies are forwarded
         for target in public_dependencies:
             self.include_public += target.directories.include_public
+            self.module_public = target.directories.module_public
+            # if target.__class__ is not HeaderOnly:
+            self.module_public += [target.output_folder]
 
-        # Make unique and resolve
+        # Make includes unique and resolve
         self.include_private = list(
             dict.fromkeys(dir.resolve() for dir in self.include_private)
         )
@@ -32,9 +42,22 @@ class Directories:
             dict.fromkeys(dir.resolve() for dir in self.include_public)
         )
 
-    def final_directories_list(self):
+        # Make module folders unique and resolve
+        self.module_private = list(
+            dict.fromkeys(dir.resolve() for dir in self.module_private)
+        )
+        self.module_public = list(
+            dict.fromkeys(dir.resolve() for dir in self.module_public)
+        )
+
+    def final_include_directories_list(self):
         return list(dict.fromkeys(self.include_private + self.include_public))
 
+    def final_module_directories_list(self):
+        return list(dict.fromkeys(self.module_private + self.module_public))
+
     def make_private_directories_public(self):
-        self.include_public = self.final_directories_list()
+        self.include_public = self.final_include_directories_list()
         self.include_private = []
+        self.module_public = self.final_module_directories_list()
+        self.module_private = []

--- a/clang_build/io_tools.py
+++ b/clang_build/io_tools.py
@@ -46,6 +46,7 @@ def get_sources_and_headers(
         "include_directories": [],
         "public_include_directories": [],
         "sourcefiles": [],
+        "modulefiles": [],
     }
 
     # TODO: maybe the output should also include the root dir, build dir and potentially download dir?
@@ -176,6 +177,32 @@ def get_sources_and_headers(
             [target_root_directory], exclude_patterns=exclude_patterns, recursive=False
         )
 
+    # Find source files from patterns (recursively)
+    if sources_patterns:
+        output["modulefiles"] += _get_files_in_patterns(
+            [target_root_directory.joinpath("*.cppm")],
+            exclude_patterns=[],
+            recursive=True,
+        )
+    # Else search source files in folder with same name as target and src folder (recursively)
+    else:
+        # output["modulefiles"] += _get_source_files_in_folders(
+        #     [
+        #         target_root_directory.joinpath(target_name),
+        #         target_root_directory.joinpath("src"),
+        #     ],
+        #     exclude_patterns=[],
+        #     recursive=True,
+        # )
+        pass
+
+    # Search the root folder as last resort (non-recursively)
+    if not output["modulefiles"]:
+        # output["modulefiles"] += _get_source_files_in_folders(
+        #     [target_root_directory], exclude_patterns=exclude_patterns, recursive=False
+        # )
+        pass
+
     # Fill return dict
     output["include_directories"] = list(dict.fromkeys(output["include_directories"]))
     output["public_include_directories"] = list(
@@ -183,5 +210,6 @@ def get_sources_and_headers(
     )
     output["headers"] = list(dict.fromkeys(output["headers"]))
     output["sourcefiles"] = list(dict.fromkeys(output["sourcefiles"]))
+    output["modulefiles"] = list(dict.fromkeys(output["modulefiles"]))
 
     return output

--- a/clang_build/project.py
+++ b/clang_build/project.py
@@ -16,6 +16,7 @@ from .logging_tools import NamedLogger as _NamedLogger
 from .target import TARGET_MAP as _TARGET_MAP
 from .target import Target as _Target
 from .target import Executable as _Executable
+from .target import Module as _Module
 from .target import HeaderOnly as _HeaderOnly
 from .target import TargetDescription as _TargetDescription
 from .tree_entry import TreeEntry as _TreeEntry
@@ -765,7 +766,7 @@ class Project(_NamedLogger, _TreeEntry):
                 )
 
             target_description.log_message(
-                f'{len(files["sourcefiles"])} source file(s) found. Creating executable target.'
+                "no module files found. Creating executable target."
             )
             return _Executable(
                 target_description, files, dependencies, public_dependencies

--- a/clang_build/toolchain.py
+++ b/clang_build/toolchain.py
@@ -39,15 +39,19 @@ class Toolchain:
             "PLATFORM": "linux",
             "EXECUTABLE_PREFIX": "",
             "EXECUTABLE_SUFFIX": "",
+            "MODULE_PREFIX": "lib",
+            "MODULE_SUFFIX": "",
             "SHARED_LIBRARY_PREFIX": "lib",
             "SHARED_LIBRARY_SUFFIX": "",
             "STATIC_LIBRARY_PREFIX": "lib",
             "STATIC_LIBRARY_SUFFIX": "",
             "PLATFORM_EXTRA_FLAGS_EXECUTABLE": [],
+            "PLATFORM_EXTRA_FLAGS_MODULE": [],
             "PLATFORM_EXTRA_FLAGS_SHARED": [],
             "PLATFORM_EXTRA_FLAGS_STATIC": [],
             "PLATFORM_BUNDLING_LINKER_FLAGS": [],
             "EXECUTABLE_OUTPUT_DIR": "bin",
+            "MODULE_OUTPUT_DIR": "mod",
             "SHARED_LIBRARY_OUTPUT_DIR": "lib",
             "STATIC_LIBRARY_OUTPUT_DIR": "lib",
             "PLATFORM_PYTHON_INCLUDE_PATH": _Path(_get_paths()["include"]),
@@ -59,15 +63,19 @@ class Toolchain:
             "PLATFORM": "osx",
             "EXECUTABLE_PREFIX": "",
             "EXECUTABLE_SUFFIX": "",
+            "MODULE_PREFIX": "lib",
+            "MODULE_SUFFIX": "",
             "SHARED_LIBRARY_PREFIX": "lib",
             "SHARED_LIBRARY_SUFFIX": "",
             "STATIC_LIBRARY_PREFIX": "lib",
             "STATIC_LIBRARY_SUFFIX": "",
             "PLATFORM_EXTRA_FLAGS_EXECUTABLE": [],
+            "PLATFORM_EXTRA_FLAGS_MODULE": [],
             "PLATFORM_EXTRA_FLAGS_SHARED": [],
             "PLATFORM_EXTRA_FLAGS_STATIC": [],
             "PLATFORM_BUNDLING_LINKER_FLAGS": [],
             "EXECUTABLE_OUTPUT_DIR": "bin",
+            "MODULE_OUTPUT_DIR": "mod",
             "SHARED_LIBRARY_OUTPUT_DIR": "lib",
             "STATIC_LIBRARY_OUTPUT_DIR": "lib",
             "PLATFORM_PYTHON_INCLUDE_PATH": _Path(_get_paths()["include"]),
@@ -79,15 +87,19 @@ class Toolchain:
             "PLATFORM": "windows",
             "EXECUTABLE_PREFIX": "",
             "EXECUTABLE_SUFFIX": "",
+            "MODULE_PREFIX": "",
+            "MODULE_SUFFIX": ".pcm",
             "SHARED_LIBRARY_PREFIX": "",
             "SHARED_LIBRARY_SUFFIX": "",
             "STATIC_LIBRARY_PREFIX": "",
             "STATIC_LIBRARY_SUFFIX": "",
             "PLATFORM_EXTRA_FLAGS_EXECUTABLE": [],
+            "PLATFORM_EXTRA_FLAGS_MODULE": [],
             "PLATFORM_EXTRA_FLAGS_SHARED": [],
             "PLATFORM_EXTRA_FLAGS_STATIC": [],
             "PLATFORM_BUNDLING_LINKER_FLAGS": [],
             "EXECUTABLE_OUTPUT_DIR": "bin",
+            "MODULE_OUTPUT_DIR": "mod",
             "SHARED_LIBRARY_OUTPUT_DIR": "bin",
             "STATIC_LIBRARY_OUTPUT_DIR": "lib",
             "PLATFORM_PYTHON_INCLUDE_PATH": _Path(_get_paths()["include"]),
@@ -118,8 +130,15 @@ class Toolchain:
         _LOGGER.info("Platform: %s", self.platform)
 
     @abstractmethod
-    def generate_dependency_file(
-        self, source_file, dependency_file, flags, include_directories, is_c_target
+    def generate_dependency_and_module_files(
+        self,
+        source_file,
+        dependency_file,
+        module_file,
+        flags,
+        include_directories,
+        module_directories,
+        is_c_target,
     ):
         """Generate a dependency file for a given source file.
 
@@ -148,7 +167,13 @@ class Toolchain:
 
     @abstractmethod
     def compile(
-        self, source_file, object_file, include_directories, flags, is_c_target
+        self,
+        source_file,
+        object_file,
+        include_directories,
+        module_directories,
+        flags,
+        is_c_target,
     ):
         """Compile a given source file into an object file.
 
@@ -300,15 +325,19 @@ class LLVM(Toolchain):
             "PLATFORM": "linux",
             "EXECUTABLE_PREFIX": "",
             "EXECUTABLE_SUFFIX": "",
+            "MODULE_PREFIX": "lib",
+            "MODULE_SUFFIX": "",
             "SHARED_LIBRARY_PREFIX": "lib",
             "SHARED_LIBRARY_SUFFIX": ".so",
             "STATIC_LIBRARY_PREFIX": "lib",
             "STATIC_LIBRARY_SUFFIX": ".a",
             "PLATFORM_EXTRA_FLAGS_EXECUTABLE": [],
+            "PLATFORM_EXTRA_FLAGS_MODULE": [],
             "PLATFORM_EXTRA_FLAGS_SHARED": ["-fpic"],
             "PLATFORM_EXTRA_FLAGS_STATIC": [],
             "PLATFORM_BUNDLING_LINKER_FLAGS": ["-Wl,-rpath,$ORIGIN"],
             "EXECUTABLE_OUTPUT_DIR": "bin",
+            "MODULE_OUTPUT_DIR": "mod",
             "SHARED_LIBRARY_OUTPUT_DIR": "lib",
             "STATIC_LIBRARY_OUTPUT_DIR": "lib",
             "PLATFORM_PYTHON_INCLUDE_PATH": _Path(_get_paths()["include"]),
@@ -320,15 +349,19 @@ class LLVM(Toolchain):
             "PLATFORM": "osx",
             "EXECUTABLE_PREFIX": "",
             "EXECUTABLE_SUFFIX": "",
+            "MODULE_PREFIX": "lib",
+            "MODULE_SUFFIX": "",
             "SHARED_LIBRARY_PREFIX": "lib",
             "SHARED_LIBRARY_SUFFIX": ".dylib",
             "STATIC_LIBRARY_PREFIX": "lib",
             "STATIC_LIBRARY_SUFFIX": ".a",
             "PLATFORM_EXTRA_FLAGS_EXECUTABLE": [],
+            "PLATFORM_EXTRA_FLAGS_MODULE": [],
             "PLATFORM_EXTRA_FLAGS_SHARED": [],
             "PLATFORM_EXTRA_FLAGS_STATIC": [],
             "PLATFORM_BUNDLING_LINKER_FLAGS": ["-Wl,-rpath,@executable_path"],
             "EXECUTABLE_OUTPUT_DIR": "bin",
+            "MODULE_OUTPUT_DIR": "mod",
             "SHARED_LIBRARY_OUTPUT_DIR": "lib",
             "STATIC_LIBRARY_OUTPUT_DIR": "lib",
             "PLATFORM_PYTHON_INCLUDE_PATH": _Path(_get_paths()["include"]),
@@ -340,6 +373,8 @@ class LLVM(Toolchain):
             "PLATFORM": "windows",
             "EXECUTABLE_PREFIX": "",
             "EXECUTABLE_SUFFIX": ".exe",
+            "MODULE_PREFIX": "",
+            "MODULE_SUFFIX": ".pcm",
             "SHARED_LIBRARY_PREFIX": "",
             "SHARED_LIBRARY_SUFFIX": ".dll",
             "STATIC_LIBRARY_PREFIX": "",
@@ -348,10 +383,12 @@ class LLVM(Toolchain):
                 "-Xclang",
                 "-flto-visibility-public-std",
             ],
+            "PLATFORM_EXTRA_FLAGS_MODULE": [],
             "PLATFORM_EXTRA_FLAGS_SHARED": ["-Xclang", "-flto-visibility-public-std"],
             "PLATFORM_EXTRA_FLAGS_STATIC": ["-Xclang", "-flto-visibility-public-std"],
             "PLATFORM_BUNDLING_LINKER_FLAGS": [],
             "EXECUTABLE_OUTPUT_DIR": "bin",
+            "MODULE_OUTPUT_DIR": "mod",
             "SHARED_LIBRARY_OUTPUT_DIR": "bin",
             "STATIC_LIBRARY_OUTPUT_DIR": "lib",
             "PLATFORM_PYTHON_INCLUDE_PATH": _Path(_get_paths()["include"]),
@@ -494,7 +531,7 @@ class LLVM(Toolchain):
 
         """
         _, report = self._run_clang_command(
-            [str(self.cpp_compiler), "-std=dummpy", "-x", "c++", "-E", "-"]
+            [str(self.cpp_compiler), "-std=dummpy", "-x", "c++", "--preprocess", "-"]
         )
 
         for line in reversed(report.splitlines()):
@@ -508,21 +545,6 @@ class LLVM(Toolchain):
     def _get_compiler(self, is_c_target):
         return [str(self.c_compiler)] if is_c_target else [str(self.cpp_compiler)]
 
-    def _get_compiler_command(
-        self, source_file, object_file, include_directories, flags, is_c_target
-    ):
-        return (
-            self._get_compiler(is_c_target)
-            + (["-o", str(object_file)] if object_file else [])
-            + ["-c", str(source_file)]
-            + flags
-            + [
-                item
-                for include_directory in include_directories
-                for item in ["-I", str(include_directory)]
-            ]
-        )
-
     def _run_clang_command(self, command):
         _LOGGER.debug(f"Running: {' '.join(command)}")
         try:
@@ -535,8 +557,15 @@ class LLVM(Toolchain):
         except _subprocess.CalledProcessError as error:
             return False, error.output.strip()
 
-    def generate_dependency_file(
-        self, source_file, dependency_file, flags, include_directories, is_c_target
+    def precompile_and_generate_dependency_file(
+        self,
+        source_file,
+        out_dependency_file,
+        out_precompiled_module_file,
+        include_directories,
+        module_directories,
+        flags,
+        is_c_target,
     ):
         """Generate a dependency file for a given source file.
 
@@ -562,15 +591,46 @@ class LLVM(Toolchain):
             Output of the compiler
 
         """
-        dependency_file.parents[0].mkdir(parents=True, exist_ok=True)
 
-        command = self._get_compiler_command(
-            source_file, None, include_directories, flags, is_c_target
-        ) + ["-E", "-MMD", str(source_file), "-MF", str(dependency_file)]
+        out_dependency_file.parents[0].mkdir(parents=True, exist_ok=True)
+        if out_precompiled_module_file:
+            out_precompiled_module_file.parents[0].mkdir(parents=True, exist_ok=True)
+
+        command = (
+            self._get_compiler(is_c_target)
+            + (
+                ["-o", str(out_precompiled_module_file)]
+                if out_precompiled_module_file
+                else []
+            )
+            + ["-MF", str(out_dependency_file)]
+            + ["-c", str(source_file)]
+            + ["--precompile", "--write-user-dependencies"]
+            + flags
+            + [
+                str(item)
+                for include_directory in include_directories
+                for item in ["-I", str(include_directory)]
+            ]
+            + [
+                str(item)
+                for module_directory in module_directories
+                for item in [f"-fprebuilt-module-path={module_directory}"]
+            ]
+        )
+
         return command, *self._run_clang_command(command)
 
     def compile(
-        self, source_file, object_file, include_directories, flags, is_c_target
+        self,
+        source_file,
+        module_file,
+        object_file,
+        include_directories,
+        module_directories,
+        flags,
+        is_c_target,
+        is_module,
     ):
         """Compile a given source file into an object file.
 
@@ -596,11 +656,27 @@ class LLVM(Toolchain):
             Output of the compiler
 
         """
+
         object_file.parents[0].mkdir(parents=True, exist_ok=True)
 
-        command = self._get_compiler_command(
-            source_file, object_file, include_directories, flags, is_c_target
+        command = (
+            self._get_compiler(is_c_target)
+            + ["-o", str(object_file), "-c"]
+            + ([str(source_file)] if not is_module else [str(module_file)])
+            + flags
+            + [
+                str(item)
+                for include_directory in include_directories
+                for item in ["-I", str(include_directory)]
+            ]
+            + [
+                str(item)
+                for module_directory in module_directories
+                for item in [f"-fprebuilt-module-path={module_directory}"]
+                if not is_module
+            ]
         )
+
         return command, *self._run_clang_command(command)
 
     def link(

--- a/test/cpp-modules/full-module/clang-build.toml
+++ b/test/cpp-modules/full-module/clang-build.toml
@@ -1,0 +1,8 @@
+[main]
+    output_name  = "main"
+    dependencies = ["hello_world"]
+    sources = ["main.cpp"]
+
+[hello_world]
+    target_type = "module"
+    sources = ["hello_world.cppm", "hello_world_impl.cpp", "hello_world_interface_world.cppm", "hello_world_impl_world.cppm"]

--- a/test/cpp-modules/full-module/hello_world-impl_world.cppm
+++ b/test/cpp-modules/full-module/hello_world-impl_world.cppm
@@ -1,0 +1,14 @@
+module;
+
+#include <iostream>
+#include <string>
+
+module hello_world:impl_world;
+import :world;
+
+std::string w = "World.";
+
+void World()
+{
+    std::cout << w << std::endl;
+}

--- a/test/cpp-modules/full-module/hello_world-world.cppm
+++ b/test/cpp-modules/full-module/hello_world-world.cppm
@@ -1,0 +1,2 @@
+export module hello_world:world;
+export void World();

--- a/test/cpp-modules/full-module/hello_world.cppm
+++ b/test/cpp-modules/full-module/hello_world.cppm
@@ -1,0 +1,6 @@
+export module hello_world;
+export import :world;
+
+import :impl_world;
+
+export void Hello();

--- a/test/cpp-modules/full-module/hello_world_impl.cpp
+++ b/test/cpp-modules/full-module/hello_world_impl.cpp
@@ -1,0 +1,8 @@
+module;
+#include <iostream>
+module hello_world;
+
+void Hello()
+{
+    std::cout << "Hello ";
+}

--- a/test/cpp-modules/full-module/main.cpp
+++ b/test/cpp-modules/full-module/main.cpp
@@ -1,0 +1,7 @@
+import hello_world;
+
+int main() {
+    Hello();
+    World();
+    return 0;
+}

--- a/test/cpp-modules/mwe/clang-build.toml
+++ b/test/cpp-modules/mwe/clang-build.toml
@@ -1,0 +1,8 @@
+[main]
+    output_name  = "main"
+    sources = ["main.cpp"]
+    dependencies = ["test"]
+
+[test]
+    target_type = "module"
+    sources = ["test.cppm"]

--- a/test/cpp-modules/mwe/main.cpp
+++ b/test/cpp-modules/mwe/main.cpp
@@ -1,0 +1,2 @@
+import test;
+int main() { test::hello(); }

--- a/test/cpp-modules/mwe/test.cppm
+++ b/test/cpp-modules/mwe/test.cppm
@@ -1,0 +1,12 @@
+module;
+
+#include <iostream>
+
+export module test;
+
+namespace test {
+
+// Functions like this need to be explicitly marked for export.
+export void hello() { std::cout << "Hello World" << std::endl; }
+
+} // namespace test


### PR DESCRIPTION
A trivial MWE module can be built, a more complete module using module partitions cannot be automatically built yet, because there seems to be no way to let clang-15 tell us the dependencies between the partitions. The user would have to manually specify the interdependencies, which doesn't seem desirable for clang-build to require.

These changes do not attempt to lay groundwork for any well-designed implementation of modules support. Instead, it's just trying to get things to compile.